### PR TITLE
Updates to request options and method naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-protoplugin
-==============
+# protoplugin
 
 [![Build](https://github.com/bufbuild/protoplugin/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/bufbuild/protoplugin/actions/workflows/ci.yaml)
 [![Report Card](https://goreportcard.com/badge/github.com/bufbuild/protoplugin)](https://goreportcard.com/report/github.com/bufbuild/protoplugin)
@@ -85,7 +84,7 @@ func handle(
 	// plugin has not indicated it will support it.
 	responseWriter.AddFeatureProto3Optional()
 
-	fileDescriptors, err := request.GenerateFileDescriptors()
+	fileDescriptors, err := request.ToGenerateFileDescriptors()
 	if err != nil {
 		return err
 	}
@@ -141,7 +140,7 @@ A Request exposes two ways to get the file information off of the `CodeGenerator
   and [`*protoregistry.Files`](https://pkg.go.dev/google.golang.org/protobuf@v1.32.0/reflect/protoregistry#Files)
 - Directly via the `FileDescriptorProtos`.
 
-The methods `GenerateFileDescriptors` and `GenerateFileDescriptorProtos` will provide file information
+The methods `ToGenerateFileDescriptors` and `ToGenerateFileDescriptorProtos` will provide file information
 only for those files specified in `file_to_generate`, while `AllFiles` and `AllFileDescriptorProtos`
 will provide file information for all files in `proto_file`.
 

--- a/internal/examples/protoc-gen-protoreflect-simple/main.go
+++ b/internal/examples/protoc-gen-protoreflect-simple/main.go
@@ -44,7 +44,7 @@ func handle(
 	// plugin has not indicated it will support it.
 	responseWriter.AddFeatureProto3Optional()
 
-	fileDescriptors, err := request.GenerateFileDescriptors()
+	fileDescriptors, err := request.ToGenerateFileDescriptors()
 	if err != nil {
 		return err
 	}

--- a/internal/examples/protoc-gen-simple/main.go
+++ b/internal/examples/protoc-gen-simple/main.go
@@ -40,7 +40,7 @@ func handle(
 	// plugin has not indicated it will support it.
 	responseWriter.AddFeatureProto3Optional()
 
-	fileDescriptorProtos, err := request.GenerateFileDescriptorProtos()
+	fileDescriptorProtos, err := request.ToGenerateFileDescriptorProtos()
 	if err != nil {
 		return err
 	}

--- a/options.go
+++ b/options.go
@@ -16,10 +16,7 @@ package protoplugin
 
 // RequestFileOption is an option for any of the file accessors on a Request.
 type RequestFileOption interface {
-	GenerateFileDescriptorProtosOption
-	AllFilesOption
-	GenerateFileDescriptorProtosOption
-	AllFileDescriptorProtosOption
+	applyRequestFileOption(requestFileOptions *requestFileOptions) error
 }
 
 // WithSourceRetentionOptions returns a new RequestFileOption that says to include
@@ -28,27 +25,10 @@ type RequestFileOption interface {
 // By default, only runtime-retention options are included on generate files. Note that
 // source-retention options are always included on non-generate files.
 func WithSourceRetentionOptions() RequestFileOption {
-	return withSourceRetentionOptions{}
-}
-
-// GenerateFileDescriptorsOption is an option for Request.GenerateFileDescriptors.
-type GenerateFileDescriptorsOption interface {
-	applyGenerateFileDescriptorsOption(requestFileOptions *requestFileOptions)
-}
-
-// AllFilesOption is an option for Request.AllFiles.
-type AllFilesOption interface {
-	applyAllFilesOption(requestFileOptions *requestFileOptions)
-}
-
-// GenerateFileDescriptorProtosOption is an option for Request.GenerateFileDescriptorProtos.
-type GenerateFileDescriptorProtosOption interface {
-	applyGenerateFileDescriptorProtosOption(requestFileOptions *requestFileOptions)
-}
-
-// AllFileDescriptorProtosOption is an option for Request.AllFileDescriptorProtos.
-type AllFileDescriptorProtosOption interface {
-	applyAllFileDescriptorProtosOption(requestFileOptions *requestFileOptions)
+	return applyRequestFileOptionFunc(func(requestFileOptions *requestFileOptions) error {
+		requestFileOptions.sourceRetentionOptions = true
+		return nil
+	})
 }
 
 // RunOption is an option for Main or Run.
@@ -76,22 +56,10 @@ func newRequestFileOptions() *requestFileOptions {
 	return &requestFileOptions{}
 }
 
-type withSourceRetentionOptions struct{}
+type applyRequestFileOptionFunc func(*requestFileOptions) error
 
-func (withSourceRetentionOptions) applyGenerateFileDescriptorsOption(requestFileOptions *requestFileOptions) {
-	requestFileOptions.sourceRetentionOptions = true
-}
-
-func (withSourceRetentionOptions) applyAllFilesOption(requestFileOptions *requestFileOptions) {
-	requestFileOptions.sourceRetentionOptions = true
-}
-
-func (withSourceRetentionOptions) applyGenerateFileDescriptorProtosOption(requestFileOptions *requestFileOptions) {
-	requestFileOptions.sourceRetentionOptions = true
-}
-
-func (withSourceRetentionOptions) applyAllFileDescriptorProtosOption(requestFileOptions *requestFileOptions) {
-	requestFileOptions.sourceRetentionOptions = true
+func (f applyRequestFileOptionFunc) applyRequestFileOption(requestFileOptions *requestFileOptions) error {
+	return f(requestFileOptions)
 }
 
 type runOptions struct {

--- a/protoplugin_test.go
+++ b/protoplugin_test.go
@@ -49,7 +49,7 @@ func TestBasic(t *testing.T) {
 				responseWriter *ResponseWriter,
 				request *Request,
 			) error {
-				fileDescriptorProtos, err := request.GenerateFileDescriptorProtos()
+				fileDescriptorProtos, err := request.ToGenerateFileDescriptorProtos()
 				if err != nil {
 					return err
 				}

--- a/request.go
+++ b/request.go
@@ -55,7 +55,7 @@ func (r *Request) Parameter() string {
 	return r.codeGeneratorRequest.GetParameter()
 }
 
-// GenerateFileDescriptors returns the FileDescriptors for the files specified by the
+// ToGenerateFileDescriptors returns the FileDescriptors for the files specified by the
 // file_to_generate field on the CodeGeneratorRequest.
 //
 // If WithSourceRetentionOptions is specified and the source_file_descriptors field was
@@ -65,7 +65,7 @@ func (r *Request) Parameter() string {
 //
 // Paths are considered valid if they are non-empty, relative, use '/' as the path separator, do not jump context,
 // and have `.proto` as the file extension.
-func (r *Request) GenerateFileDescriptors(options ...GenerateFileDescriptorsOption) ([]protoreflect.FileDescriptor, error) {
+func (r *Request) ToGenerateFileDescriptors(options ...GenerateFileDescriptorsOption) ([]protoreflect.FileDescriptor, error) {
 	requestFileOptions := newRequestFileOptions()
 	for _, option := range options {
 		option.applyGenerateFileDescriptorsOption(requestFileOptions)
@@ -106,7 +106,7 @@ func (r *Request) AllFiles(options ...AllFilesOption) (*protoregistry.Files, err
 	return r.allFiles(requestFileOptions.sourceRetentionOptions)
 }
 
-// GenerateFileDescriptorProtos returns the FileDescriptors for the files specified by the
+// ToGenerateFileDescriptorProtos returns the FileDescriptors for the files specified by the
 // file_to_generate field.
 //
 // If WithSourceRetentionOptions is specified and the source_file_descriptors field was
@@ -116,7 +116,7 @@ func (r *Request) AllFiles(options ...AllFilesOption) (*protoregistry.Files, err
 //
 // Paths are considered valid if they are non-empty, relative, use '/' as the path separator, do not jump context,
 // and have `.proto` as the file extension.
-func (r *Request) GenerateFileDescriptorProtos(options ...GenerateFileDescriptorProtosOption) ([]*descriptorpb.FileDescriptorProto, error) {
+func (r *Request) ToGenerateFileDescriptorProtos(options ...GenerateFileDescriptorProtosOption) ([]*descriptorpb.FileDescriptorProto, error) {
 	requestFileOptions := newRequestFileOptions()
 	for _, option := range options {
 		option.applyGenerateFileDescriptorProtosOption(requestFileOptions)

--- a/request.go
+++ b/request.go
@@ -65,10 +65,10 @@ func (r *Request) Parameter() string {
 //
 // Paths are considered valid if they are non-empty, relative, use '/' as the path separator, do not jump context,
 // and have `.proto` as the file extension.
-func (r *Request) ToGenerateFileDescriptors(options ...GenerateFileDescriptorsOption) ([]protoreflect.FileDescriptor, error) {
+func (r *Request) ToGenerateFileDescriptors(options ...RequestFileOption) ([]protoreflect.FileDescriptor, error) {
 	requestFileOptions := newRequestFileOptions()
 	for _, option := range options {
-		option.applyGenerateFileDescriptorsOption(requestFileOptions)
+		option.applyRequestFileOption(requestFileOptions)
 	}
 	files, err := r.allFiles(requestFileOptions.sourceRetentionOptions)
 	if err != nil {
@@ -98,10 +98,10 @@ func (r *Request) ToGenerateFileDescriptors(options ...GenerateFileDescriptorsOp
 //
 // Paths are considered valid if they are non-empty, relative, use '/' as the path separator, do not jump context,
 // and have `.proto` as the file extension.
-func (r *Request) AllFiles(options ...AllFilesOption) (*protoregistry.Files, error) {
+func (r *Request) AllFiles(options ...RequestFileOption) (*protoregistry.Files, error) {
 	requestFileOptions := newRequestFileOptions()
 	for _, option := range options {
-		option.applyAllFilesOption(requestFileOptions)
+		option.applyRequestFileOption(requestFileOptions)
 	}
 	return r.allFiles(requestFileOptions.sourceRetentionOptions)
 }
@@ -116,10 +116,10 @@ func (r *Request) AllFiles(options ...AllFilesOption) (*protoregistry.Files, err
 //
 // Paths are considered valid if they are non-empty, relative, use '/' as the path separator, do not jump context,
 // and have `.proto` as the file extension.
-func (r *Request) ToGenerateFileDescriptorProtos(options ...GenerateFileDescriptorProtosOption) ([]*descriptorpb.FileDescriptorProto, error) {
+func (r *Request) ToGenerateFileDescriptorProtos(options ...RequestFileOption) ([]*descriptorpb.FileDescriptorProto, error) {
 	requestFileOptions := newRequestFileOptions()
 	for _, option := range options {
-		option.applyGenerateFileDescriptorProtosOption(requestFileOptions)
+		option.applyRequestFileOption(requestFileOptions)
 	}
 	return r.generateFileDescriptorProtos(requestFileOptions.sourceRetentionOptions)
 }
@@ -137,10 +137,10 @@ func (r *Request) ToGenerateFileDescriptorProtos(options ...GenerateFileDescript
 //
 // Paths are considered valid if they are non-empty, relative, use '/' as the path separator, do not jump context,
 // and have `.proto` as the file extension.
-func (r *Request) AllFileDescriptorProtos(options ...AllFileDescriptorProtosOption) ([]*descriptorpb.FileDescriptorProto, error) {
+func (r *Request) AllFileDescriptorProtos(options ...RequestFileOption) ([]*descriptorpb.FileDescriptorProto, error) {
 	requestFileOptions := newRequestFileOptions()
 	for _, option := range options {
-		option.applyAllFileDescriptorProtosOption(requestFileOptions)
+		option.applyRequestFileOption(requestFileOptions)
 	}
 	return r.allFileDescriptorProtos(requestFileOptions.sourceRetentionOptions)
 }

--- a/request.go
+++ b/request.go
@@ -121,7 +121,7 @@ func (r *Request) ToGenerateFileDescriptorProtos(options ...RequestFileOption) (
 	for _, option := range options {
 		option.applyRequestFileOption(requestFileOptions)
 	}
-	return r.generateFileDescriptorProtos(requestFileOptions.sourceRetentionOptions)
+	return r.toGenerateFileDescriptorProtos(requestFileOptions.sourceRetentionOptions)
 }
 
 // AllFileDescriptorProtos returns the FileDescriptorProtos for all files in the CodeGeneratorRequest.
@@ -197,7 +197,7 @@ func (r *Request) allFiles(sourceRetentionOptions bool) (*protoregistry.Files, e
 	return protodesc.NewFiles(&descriptorpb.FileDescriptorSet{File: fileDescriptorProtos})
 }
 
-func (r *Request) generateFileDescriptorProtos(sourceRetentionOptions bool) ([]*descriptorpb.FileDescriptorProto, error) {
+func (r *Request) toGenerateFileDescriptorProtos(sourceRetentionOptions bool) ([]*descriptorpb.FileDescriptorProto, error) {
 	// If we want source-retention options, source_file_descriptors is all we need.
 	if sourceRetentionOptions {
 		if err := r.validateSourceFileDescriptorsPresent(); err != nil {

--- a/request.go
+++ b/request.go
@@ -68,7 +68,9 @@ func (r *Request) Parameter() string {
 func (r *Request) ToGenerateFileDescriptors(options ...RequestFileOption) ([]protoreflect.FileDescriptor, error) {
 	requestFileOptions := newRequestFileOptions()
 	for _, option := range options {
-		option.applyRequestFileOption(requestFileOptions)
+		if err := option.applyRequestFileOption(requestFileOptions); err != nil {
+			return nil, err
+		}
 	}
 	files, err := r.allFiles(requestFileOptions.sourceRetentionOptions)
 	if err != nil {
@@ -101,7 +103,9 @@ func (r *Request) ToGenerateFileDescriptors(options ...RequestFileOption) ([]pro
 func (r *Request) AllFiles(options ...RequestFileOption) (*protoregistry.Files, error) {
 	requestFileOptions := newRequestFileOptions()
 	for _, option := range options {
-		option.applyRequestFileOption(requestFileOptions)
+		if err := option.applyRequestFileOption(requestFileOptions); err != nil {
+			return nil, err
+		}
 	}
 	return r.allFiles(requestFileOptions.sourceRetentionOptions)
 }
@@ -119,7 +123,9 @@ func (r *Request) AllFiles(options ...RequestFileOption) (*protoregistry.Files, 
 func (r *Request) ToGenerateFileDescriptorProtos(options ...RequestFileOption) ([]*descriptorpb.FileDescriptorProto, error) {
 	requestFileOptions := newRequestFileOptions()
 	for _, option := range options {
-		option.applyRequestFileOption(requestFileOptions)
+		if err := option.applyRequestFileOption(requestFileOptions); err != nil {
+			return nil, err
+		}
 	}
 	return r.toGenerateFileDescriptorProtos(requestFileOptions.sourceRetentionOptions)
 }
@@ -140,7 +146,9 @@ func (r *Request) ToGenerateFileDescriptorProtos(options ...RequestFileOption) (
 func (r *Request) AllFileDescriptorProtos(options ...RequestFileOption) ([]*descriptorpb.FileDescriptorProto, error) {
 	requestFileOptions := newRequestFileOptions()
 	for _, option := range options {
-		option.applyRequestFileOption(requestFileOptions)
+		if err := option.applyRequestFileOption(requestFileOptions); err != nil {
+			return nil, err
+		}
 	}
 	return r.allFileDescriptorProtos(requestFileOptions.sourceRetentionOptions)
 }


### PR DESCRIPTION
This PR does 2 things:

1. Rename generate`*Request` methods from:

- `GenerateFileDescriptors` to `ToGenerateFileDescriptors`
- `GenerateFileDescriptorProtos` to `ToGenerateFileDescriptorProtos`

2. Consolidate options into a single `RequestFileOption`

This felt a bit cleaner as opposed to having 4 different options for the same thing. Mainly wanted to put this PR up to see how this felt like as an end-user. 