### PR TITLE
Add version support

### DIFF
--- a/internal/examples/protoc-gen-protogen-simple/main.go
+++ b/internal/examples/protoc-gen-protogen-simple/main.go
@@ -28,8 +28,10 @@ import (
 	"google.golang.org/protobuf/compiler/protogen"
 )
 
+const version = "0.0.1"
+
 func main() {
-	protoplugin.Main(protoplugin.HandlerFunc(handle))
+	protoplugin.Main(protoplugin.HandlerFunc(handle), protoplugin.WithVersion(version))
 }
 
 func handle(

--- a/internal/examples/protoc-gen-protoreflect-simple/main.go
+++ b/internal/examples/protoc-gen-protoreflect-simple/main.go
@@ -30,8 +30,10 @@ import (
 	"github.com/bufbuild/protoplugin"
 )
 
+const version = "0.0.1"
+
 func main() {
-	protoplugin.Main(protoplugin.HandlerFunc(handle))
+	protoplugin.Main(protoplugin.HandlerFunc(handle), protoplugin.WithVersion(version))
 }
 
 func handle(

--- a/internal/examples/protoc-gen-simple/main.go
+++ b/internal/examples/protoc-gen-simple/main.go
@@ -26,8 +26,10 @@ import (
 	"github.com/bufbuild/protoplugin"
 )
 
+const version = "0.0.1"
+
 func main() {
-	protoplugin.Main(protoplugin.HandlerFunc(handle))
+	protoplugin.Main(protoplugin.HandlerFunc(handle), protoplugin.WithVersion(version))
 }
 
 func handle(

--- a/protoplugin.go
+++ b/protoplugin.go
@@ -118,7 +118,7 @@ func run(
 	handler Handler,
 	runOptions *runOptions,
 ) error {
-	if len(args) > 0 {
+	if len(args) > 1 {
 		name := args[0]
 		for _, arg := range args[1:] {
 			switch arg {

--- a/protoplugin.go
+++ b/protoplugin.go
@@ -124,12 +124,11 @@ func run(
 	handler Handler,
 	runOptions *runOptions,
 ) error {
-	fmt.Println("here")
 	switch len(args) {
 	case 0:
 	case 1:
-		if args[0] == "--version" {
-			_, err := fmt.Fprintln(stdout, args[0])
+		if runOptions.version != "" && args[0] == "--version" {
+			_, err := fmt.Fprintln(stdout, runOptions.version)
 			return err
 		}
 		return fmt.Errorf("unknown argument: %s", args[0])
@@ -137,9 +136,8 @@ func run(
 		return fmt.Errorf("unknown arguments: %v", strings.Join(args, " "))
 	}
 
-	warningHandlerFunc := runOptions.warningHandlerFunc
-	if warningHandlerFunc == nil {
-		warningHandlerFunc = func(err error) { _, _ = fmt.Fprintln(stderr, err.Error()) }
+	if runOptions.warningHandlerFunc == nil {
+		runOptions.warningHandlerFunc = func(err error) { _, _ = fmt.Fprintln(stderr, err.Error()) }
 	}
 
 	input, err := io.ReadAll(stdin)
@@ -154,7 +152,7 @@ func run(
 	if err != nil {
 		return err
 	}
-	responseWriter := newResponseWriter(warningHandlerFunc)
+	responseWriter := newResponseWriter(runOptions.warningHandlerFunc)
 	if err := handler.Handle(ctx, responseWriter, request); err != nil {
 		return err
 	}


### PR DESCRIPTION
If `WithVersion` is specified, `--version` prints the user-supplied version to stdout.

```sh
$ protoc-gen-debug
0.0.1
```