### PR TITLE
Convert Request and ResponseWriter to interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ func main() {
 
 func handle(
 	_ context.Context,
-  _ *protoplugin.HandlerEnv,
-	responseWriter *protoplugin.ResponseWriter,
-	request *protoplugin.Request,
+  _ protoplugin.PluginEnv,
+	responseWriter protoplugin.ResponseWriter,
+	request protoplugin.Request,
 ) error {
 	// Set the flag indicating that we support proto3 optionals. We don't even use them in this
 	// plugin, but protoc will error if it encounters a proto3 file with an optional but the
@@ -193,7 +193,7 @@ Errors or warnings will also be produced if:
   a duplicate name is plugin authoring issue, and here at Buf, we've seen a lot of plugins have this issue!
 - Any file path is not cleaned.
 
-By default, these are errors, however if `WithLenientResponseValidation` is set, these will be warnings.
+By default, these are errors, however if `WithLenientValidation` is set, these will be warnings.
 
 ## What this library is not
 

--- a/env.go
+++ b/env.go
@@ -16,7 +16,7 @@ package protoplugin
 
 import "io"
 
-// Env represents an environment for a plugin to run within.
+// Env represents an environment.
 //
 // This wraps items like args, environment variables, and stdio.
 //
@@ -37,13 +37,13 @@ type Env struct {
 	Stderr io.Writer
 }
 
-// HandlerEnv represents an environment that a Handler is run within.
+// PluginEnv represents an environment that a plugin is run within.
 //
-// This provides the environment variables and stderr to a Handler. A Handler should not have
+// This provides the environment variables and stderr. A plugin implementation should not have
 // access to stdin, stdout, or the args, as these are controlled by the plugin framework.
 //
 // When calling Main, this uses the values os.Environ and os.Stderr.
-type HandlerEnv struct {
+type PluginEnv struct {
 	// Environment are the environment variables.
 	Environ []string
 	// Stderr is the stderr for the plugin.

--- a/handler.go
+++ b/handler.go
@@ -44,21 +44,21 @@ type Handler interface {
 	// (for example, a missing option), this error should be added to the response via SetError.
 	Handle(
 		ctx context.Context,
-		handlerEnv *HandlerEnv,
-		responseWriter *ResponseWriter,
-		request *Request,
+		pluginEnv PluginEnv,
+		responseWriter ResponseWriter,
+		request Request,
 	) error
 }
 
 // HandlerFunc is a function that implements Handler.
-type HandlerFunc func(context.Context, *HandlerEnv, *ResponseWriter, *Request) error
+type HandlerFunc func(context.Context, PluginEnv, ResponseWriter, Request) error
 
 // Handle implements Handler.
 func (h HandlerFunc) Handle(
 	ctx context.Context,
-	handlerEnv *HandlerEnv,
-	responseWriter *ResponseWriter,
-	request *Request,
+	pluginEnv PluginEnv,
+	responseWriter ResponseWriter,
+	request Request,
 ) error {
-	return h(ctx, handlerEnv, responseWriter, request)
+	return h(ctx, pluginEnv, responseWriter, request)
 }

--- a/internal/examples/protoc-gen-protogen-simple/main.go
+++ b/internal/examples/protoc-gen-protogen-simple/main.go
@@ -36,9 +36,9 @@ func main() {
 
 func handle(
 	_ context.Context,
-	_ *protoplugin.HandlerEnv,
-	responseWriter *protoplugin.ResponseWriter,
-	request *protoplugin.Request,
+	_ protoplugin.PluginEnv,
+	responseWriter protoplugin.ResponseWriter,
+	request protoplugin.Request,
 ) error {
 	plugin, err := protogen.Options{}.New(request.CodeGeneratorRequest())
 	if err != nil {

--- a/internal/examples/protoc-gen-protoreflect-simple/main.go
+++ b/internal/examples/protoc-gen-protoreflect-simple/main.go
@@ -38,9 +38,9 @@ func main() {
 
 func handle(
 	_ context.Context,
-	_ *protoplugin.HandlerEnv,
-	responseWriter *protoplugin.ResponseWriter,
-	request *protoplugin.Request,
+	_ protoplugin.PluginEnv,
+	responseWriter protoplugin.ResponseWriter,
+	request protoplugin.Request,
 ) error {
 	// Set the flag indicating that we support proto3 optionals. We don't even use them in this
 	// plugin, but protoc will error if it encounters a proto3 file with an optional but the

--- a/internal/examples/protoc-gen-simple/main.go
+++ b/internal/examples/protoc-gen-simple/main.go
@@ -34,9 +34,9 @@ func main() {
 
 func handle(
 	_ context.Context,
-	_ *protoplugin.HandlerEnv,
-	responseWriter *protoplugin.ResponseWriter,
-	request *protoplugin.Request,
+	_ protoplugin.PluginEnv,
+	responseWriter protoplugin.ResponseWriter,
+	request protoplugin.Request,
 ) error {
 	// Set the flag indicating that we support proto3 optionals. We don't even use them in this
 	// plugin, but protoc will error if it encounters a proto3 file with an optional but the

--- a/protoplugin_test.go
+++ b/protoplugin_test.go
@@ -47,9 +47,9 @@ func TestBasic(t *testing.T) {
 		HandlerFunc(
 			func(
 				ctx context.Context,
-				handlerEnv *HandlerEnv,
-				responseWriter *ResponseWriter,
-				request *Request,
+				pluginEnv PluginEnv,
+				responseWriter ResponseWriter,
+				request Request,
 			) error {
 				for _, fileDescriptorProto := range request.FileDescriptorProtosToGenerate() {
 					topLevelMessageNames := make([]string, len(fileDescriptorProto.GetMessageType()))
@@ -77,14 +77,14 @@ func TestWithVersionOption(t *testing.T) {
 		stdout := bytes.NewBuffer(nil)
 		err := Run(
 			context.Background(),
-			&Env{
+			Env{
 				Args:    args,
 				Environ: nil,
 				Stdin:   iotest.ErrReader(io.EOF),
 				Stdout:  stdout,
 				Stderr:  io.Discard,
 			},
-			HandlerFunc(func(ctx context.Context, _ *HandlerEnv, _ *ResponseWriter, _ *Request) error { return nil }),
+			HandlerFunc(func(ctx context.Context, _ PluginEnv, _ ResponseWriter, _ Request) error { return nil }),
 			runOptions...,
 		)
 		return stdout.String(), err
@@ -129,7 +129,7 @@ func testBasic(
 
 	err = Run(
 		ctx,
-		&Env{
+		Env{
 			Args:    nil,
 			Environ: nil,
 			Stdin:   stdin,


### PR DESCRIPTION
The primary purpose of this PR is to convert `Request` and `ResponseWriter` into interfaces that each contain a private method, preventing construction outside of this module.

Our motivation for this started with wanting to not duplicate logic across `buf` and `protoplugin`. There's some work we have to do to support editions that effectively would be repeated in both modules, and `protoplugin` already largely copies the protoplugin package within `buf` - it's how this module started in the first place. By centralizing the logic, we get one place to keep it up to date, and a concentrated set of (soon to be added) testing within this module to make sure it all works properly. We already had better validation within `protoplugin` than we ever had in `buf`, and we want to take advantage of that while we work to support editions.

`buf`, however, does some special things that other plugin authors won't do. Specifically, it has the ability to take multiple `CodeGeneratorRequests`, and output a single `CodeGeneratorResponse` after executing the equivalent of a `Handler` in parallel. No one should do this outside of `buf` - it's a super-speciality use-case, and creating parallelizable `CodeGeneratorRequests` correctly is a challenge in itself - few need to proxy to other plugins, let alone in parallel. Part of what `buf` does is call what amounts to `newRequest` for each `CodeGeneratorRequest`, and create a single `ResponseWriter` that each parallel call calls to.

Before this PR, `protoplugin` had the `Request` and `ResponseWriter` types as structs, without any useful ability to create these types outside of this package and use them. This was fine, as we purposefully wanted to limit `Handler` invocation to the `Main` and `Run` functions. However, to take advantage of `protoplugin` within `buf`, and to allow the parallel execution use case, we had to do one of two things:

1. Re-create the parallel logic within `protoplugin` itself. This seemed bad, and would dirty up the API for this single use case.
2. Make it possible to create `Requests` and `ResponseWriters` in useful ways, and then support the use case of `Handlers` being invoked outside of `Main` or `Run`.

(2) seemed preferable, including outside of this specific use case - if we expose these `Request` and `ResponseWriter` types, and tell users to implement a `Handler` type, it seems appropriate to let users invoke these `Handlers` (including in testing) on their own. However, a central tenant of this package is that users can rely on `Requests` being validated, and `ResponseWriters` behaving appropriately. If we're telling users to construct their own `Requests`, and `Requests` were structs, Golang idiomatic behavior would say that `request := &protoplugin.Request{}` should be a valid way to construct a request. We need to force users through a constructor, however, for `Request` in its current form (which we like) to make any sense - validation has to be performed, and we want users to rely on the fact that `Requests` are always valid.

@mfridman and I discussed this approach offline and this seemed to make the most sense. @mfridman, this is the result of that - let me know what you think.

Of note, this also does the rename of `HandlerEnv` to `PluginEnv`, and removes the usage of pointers for `Env` and `PluginEnv` - the pointers don't really make sense in this case, and now that we're leaning into interfaces, there's less of an argument to use pointers to be consistent within this library. `CompilerVersion` remains a pointer when returned from`Request`, as presence is important.

The API will likely evolve further from here - it's not great that there are  two options `WithLenientValidation` and `ResponseWriterWithLenientValidation`. But this gets the basics in.