### PR TITLE
Prevent streams from being nil

### DIFF
--- a/protoplugin.go
+++ b/protoplugin.go
@@ -153,6 +153,15 @@ func run(
 	handler Handler,
 	opts *opts,
 ) error {
+	if env.Stderr == nil {
+		return errors.New("failed to run: stderr is required")
+	}
+	if env.Stdin == nil {
+		return errors.New("failed to run: stdin is required")
+	}
+	if env.Stdout == nil {
+		return errors.New("failed to run: stdout is required")
+	}
 	switch len(env.Args) {
 	case 0:
 	case 1:


### PR DESCRIPTION
Putting this up for discussion. 

Should we protect users from accidentally forgetting to set one of stdin, stdout or stderr to `nil` to avoid a panic?

The alternative, instead of failing with an error, is to set these to a sane default like os.Stdin, os.Stdout, os.Stderr.

Either option, sane default or explicit error, seems better than a panic?

EDIT: one more alternative -- have a `WithEnv` option, where `run` uses os.Stdin, os.Stdout, os.Stderr by default, but the caller can modify this behavior with a supplied option.