### PR TITLE
Update go and golangci-lint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.20.x, 1.21.x, 1.22.x, 1.23.x]
+        go-version: [1.21.x, 1.22.x, 1.23.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.20.x, 1.21.x, 1.22.x]
+        go-version: [1.20.x, 1.21.x, 1.22.x, 1.23.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -32,5 +32,5 @@ jobs:
         # conflicting guidance, run only on the most recent supported version.
         # For the same reason, only check generated code on the most recent
         # supported version.
-        if: matrix.go-version == '1.22.x'
+        if: matrix.go-version == '1.23.x'
         run: make checkgenerate && make lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,10 +20,12 @@ linters-settings:
 linters:
   enable-all: true
   disable:
+    - copyloopvar       # only valid for go v1.22 and above
     - cyclop            # covered by gocyclo
     - depguard          # unnecessary for small libraries
     - execinquery       # deprecated in golangci v1.58 
     - exhaustruct       # many exceptions
+    - exportloopref     # deprecated in golangci v1.60.2
     - funlen            # rely on code review to limit function length
     - gochecknoglobals  # many exceptions
     - gocognit          # dubious "cognitive overhead" quantification
@@ -31,6 +33,7 @@ linters:
     - goimports         # rely on gci instead
     - gomnd             # deprecated in golangci v1.58 in favor of mnd
     - mnd               # some unnamed constants are okay
+    - intrange          # only valid for go v1.22 and above
     - ireturn           # "accept interfaces, return structs" isn't ironclad
     - lll               # don't want hard limits for line length
     - maintidx          # covered by gocyclo

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,3 @@
-run:
-  skip-dirs-use-default: false
 linters-settings:
   errcheck:
     check-type-assertions: true
@@ -24,36 +22,29 @@ linters:
   disable:
     - cyclop            # covered by gocyclo
     - depguard          # unnecessary for small libraries
-    - deadcode          # abandoned
-    - exhaustivestruct  # replaced by exhaustruct
+    - execinquery       # deprecated in golangci v1.58 
     - exhaustruct       # many exceptions
     - funlen            # rely on code review to limit function length
     - gochecknoglobals  # many exceptions
     - gocognit          # dubious "cognitive overhead" quantification
     - gofumpt           # prefer standard gofmt
     - goimports         # rely on gci instead
-    - golint            # deprecated by Go team
-    - gomnd             # some unnamed constants are okay
-    - ifshort           # deprecated by author
-    - interfacer        # deprecated by author
+    - gomnd             # deprecated in golangci v1.58 in favor of mnd
+    - mnd               # some unnamed constants are okay
     - ireturn           # "accept interfaces, return structs" isn't ironclad
     - lll               # don't want hard limits for line length
     - maintidx          # covered by gocyclo
-    - maligned          # readability trumps efficient struct packing
     - nlreturn          # generous whitespace violates house style
-    - nosnakecase       # deprecated in https://github.com/golangci/golangci-lint/pull/3065
-    - scopelint         # deprecated by author
-    - structcheck       # abandoned
     - testpackage       # internal tests are fine
     - thelper           # we want to print out the whole stack
-    - varcheck          # abandoned
     - wrapcheck         # don't _always_ need to wrap errors
     - wsl               # generous whitespace violates house style
 issues:
+  exclude-dirs-use-default: false
   exclude:
     # Don't ban use of fmt.Errorf to create new errors, but the remaining
     # checks from err113 are useful.
-    - "err113: do not define dynamic errors.*"
+    - "do not define dynamic errors.*"
   exclude-rules:
     - linters:
       - nilnil

--- a/Makefile
+++ b/Makefile
@@ -70,4 +70,4 @@ $(BIN)/license-header: Makefile
 
 $(BIN)/golangci-lint: Makefile
 	@mkdir -p $(@D)
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.0
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.3

--- a/Makefile
+++ b/Makefile
@@ -70,4 +70,4 @@ $(BIN)/license-header: Makefile
 
 $(BIN)/golangci-lint: Makefile
 	@mkdir -p $(@D)
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.1
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.0

--- a/compiler_version.go
+++ b/compiler_version.go
@@ -92,13 +92,13 @@ func (c *CompilerVersion) ToProto() *pluginpb.Version {
 	}
 	version := &pluginpb.Version{}
 	if c.Major != 0 {
-		version.Major = proto.Int32(int32(c.Major))
+		version.Major = proto.Int32(int32(c.Major)) // #nosec:G115 should never overflow
 	}
 	if c.Minor != 0 {
-		version.Minor = proto.Int32(int32(c.Minor))
+		version.Minor = proto.Int32(int32(c.Minor)) // #nosec:G115 should never overflow
 	}
 	if c.Patch != 0 {
-		version.Patch = proto.Int32(int32(c.Patch))
+		version.Patch = proto.Int32(int32(c.Patch)) // #nosec:G115 should never overflow
 	}
 	if c.Suffix != "" {
 		version.Suffix = proto.String(c.Suffix)

--- a/errors.go
+++ b/errors.go
@@ -33,9 +33,9 @@ func newUnknownArgumentsError(args []string) error {
 
 func (a *unknownArgumentsError) Error() string {
 	if len(a.args) == 1 {
-		return fmt.Sprintf("unknown argument: %s", a.args[0])
+		return "unknown argument: " + a.args[0]
 	}
-	return fmt.Sprintf("unknown arguments: %s", strings.Join(a.args, " "))
+	return "unknown arguments: " + strings.Join(a.args, " ")
 }
 
 // unnormalizedCodeGeneratorResponseFileNameError is the error returned if a

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bufbuild/protoplugin
 
-go 1.20
+go 1.22
 
 require (
 	github.com/bufbuild/protocompile v0.9.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bufbuild/protoplugin
 
-go 1.22
+go 1.21
 
 require (
 	github.com/bufbuild/protocompile v0.9.0

--- a/internal/examples/protoc-gen-protoreflect-simple/main.go
+++ b/internal/examples/protoc-gen-protoreflect-simple/main.go
@@ -54,7 +54,7 @@ func handle(
 	for _, fileDescriptor := range fileDescriptors {
 		messages := fileDescriptor.Messages()
 		topLevelMessageNames := make([]string, messages.Len())
-		for i := 0; i < messages.Len(); i++ { //nolint:intrange
+		for i := 0; i < messages.Len(); i++ {
 			topLevelMessageNames[i] = string(messages.Get(i).Name())
 		}
 		// Add the response file to the response.

--- a/internal/examples/protoc-gen-protoreflect-simple/main.go
+++ b/internal/examples/protoc-gen-protoreflect-simple/main.go
@@ -54,7 +54,7 @@ func handle(
 	for _, fileDescriptor := range fileDescriptors {
 		messages := fileDescriptor.Messages()
 		topLevelMessageNames := make([]string, messages.Len())
-		for i := 0; i < messages.Len(); i++ {
+		for i := 0; i < messages.Len(); i++ { //nolint:intrange
 			topLevelMessageNames[i] = string(messages.Get(i).Name())
 		}
 		// Add the response file to the response.

--- a/protoplugin_test.go
+++ b/protoplugin_test.go
@@ -46,8 +46,8 @@ func TestBasic(t *testing.T) {
 		},
 		HandlerFunc(
 			func(
-				ctx context.Context,
-				pluginEnv PluginEnv,
+				_ context.Context,
+				_ PluginEnv,
 				responseWriter ResponseWriter,
 				request Request,
 			) error {
@@ -84,7 +84,7 @@ func TestWithVersionOption(t *testing.T) {
 				Stdout:  stdout,
 				Stderr:  io.Discard,
 			},
-			HandlerFunc(func(ctx context.Context, _ PluginEnv, _ ResponseWriter, _ Request) error { return nil }),
+			HandlerFunc(func(_ context.Context, _ PluginEnv, _ ResponseWriter, _ Request) error { return nil }),
 			runOptions...,
 		)
 		return stdout.String(), err

--- a/protopluginutil/source_retention_options.go
+++ b/protopluginutil/source_retention_options.go
@@ -131,7 +131,7 @@ func stripSourceRetentionOptionsFromProtoMessage[M proto.Message](
 	var hasFieldToStrip bool
 	var numFieldsToKeep int
 	var err error
-	optionsRef.Range(func(field protoreflect.FieldDescriptor, val protoreflect.Value) bool {
+	optionsRef.Range(func(field protoreflect.FieldDescriptor, _ protoreflect.Value) bool {
 		fieldOpts, ok := field.Options().(*descriptorpb.FieldOptions)
 		if !ok {
 			err = fmt.Errorf("field options is unexpected type: got %T, want %T", field.Options(), fieldOpts)

--- a/protopluginutil/source_retention_options.go
+++ b/protopluginutil/source_retention_options.go
@@ -493,7 +493,8 @@ func stripOptionsFromAll[T comparable](
 ) ([]T, bool, error) {
 	var updated []T // initialized lazily, only when/if a copy is needed
 	for i, item := range slice {
-		newItem, err := updateFunc(item, path.push(int32(i)), removedPaths)
+		index := int32(i) // #nosec:G115 should never overflow
+		newItem, err := updateFunc(item, path.push(index), removedPaths)
 		if err != nil {
 			return nil, false, err
 		}

--- a/validate.go
+++ b/validate.go
@@ -182,10 +182,10 @@ func validateAndNormalizeCodeGeneratorResponse(
 	}
 	if response.GetSupportedFeatures()&uint64(pluginpb.CodeGeneratorResponse_FEATURE_SUPPORTS_EDITIONS) != 0 {
 		if response.GetMinimumEdition() == 0 {
-			return fmt.Errorf("supported_features: FEATURE_SUPPORTS_EDITIONS specified but no minimum_edition set")
+			return errors.New("supported_features: FEATURE_SUPPORTS_EDITIONS specified but no minimum_edition set")
 		}
 		if response.GetMaximumEdition() == 0 {
-			return fmt.Errorf("supported_features: FEATURE_SUPPORTS_EDITIONS specified but no maximum_edition set")
+			return errors.New("supported_features: FEATURE_SUPPORTS_EDITIONS specified but no maximum_edition set")
 		}
 		if response.GetMinimumEdition() > response.GetMaximumEdition() {
 			return fmt.Errorf(


### PR DESCRIPTION
Now that a new version of Go has been released, this bumps the versions used in this repo and drops support for Go v1.20.

This also updates golangci-lint to the latest, which called for some config changes to eliminate warnings.